### PR TITLE
Added test for PageFetcher + updated PageFetcherConfig to include a testConfig

### DIFF
--- a/vat-crawler/build.gradle
+++ b/vat-crawler/build.gradle
@@ -63,6 +63,8 @@ dependencies {
   // https://mvnrepository.com/artifact/com.github.tomakehurst/wiremock
   testImplementation group: 'com.github.tomakehurst', name: 'wiremock', version: '2.27.2'
 
+  testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
+
 }
 
 jib {

--- a/vat-crawler/src/main/java/be/dnsbelgium/mercator/vat/domain/PageFetcherConfig.java
+++ b/vat-crawler/src/main/java/be/dnsbelgium/mercator/vat/domain/PageFetcherConfig.java
@@ -25,6 +25,7 @@ public class PageFetcherConfig {
   private final Duration writeTimeOut;
   private final Duration cacheMaxStale;
   private final String userAgent;
+  private final DataSize maxContentLength;
 
   private final static String DEFAULT_USER_AGENT
       = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:87.0) Gecko/20100101 Firefox/87.0";
@@ -40,7 +41,9 @@ public class PageFetcherConfig {
       @DefaultValue("5s")           Duration writeTimeOut,
       @DefaultValue("5s")           Duration callTimeOut,
       @DefaultValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:87.0) Gecko/20100101 Firefox/87.0")
-                                    String userAgent
+                                    String userAgent,
+      @DefaultValue("8MB")
+                                    DataSize maxContentLength
       ) {
     this.cacheDirectory = cacheDirectory;
     this.cacheSize = cacheSize;
@@ -52,6 +55,7 @@ public class PageFetcherConfig {
     this.writeTimeOut = writeTimeOut;
     this.callTimeOut = callTimeOut;
     this.userAgent = userAgent;
+    this.maxContentLength = maxContentLength;
   }
 
   public static PageFetcherConfig defaultConfig() {
@@ -63,7 +67,22 @@ public class PageFetcherConfig {
         Duration.ofSeconds(5),
         Duration.ofSeconds(5),
         Duration.ofSeconds(8),
-        DEFAULT_USER_AGENT
+        DEFAULT_USER_AGENT,
+        DataSize.of(8, DataUnit.MEGABYTES)
+    );
+  }
+
+  public static PageFetcherConfig testConfig() {
+    return new PageFetcherConfig(
+        new File("/tmp/cache/"),
+        DataSize.of(100, DataUnit.MEGABYTES),
+        Duration.ofHours(24),
+        Duration.ofSeconds(5),
+        Duration.ofSeconds(5),
+        Duration.ofSeconds(5),
+        Duration.ofSeconds(8),
+        DEFAULT_USER_AGENT,
+        DataSize.of(100, DataUnit.KILOBYTES)
     );
   }
 
@@ -99,6 +118,10 @@ public class PageFetcherConfig {
     return userAgent;
   }
 
+  public DataSize getMaxContentLength() {
+    return maxContentLength;
+  }
+
   @Override
   public String toString() {
     return new StringJoiner(", ", PageFetcherConfig.class.getSimpleName() + "[", "]")
@@ -109,6 +132,7 @@ public class PageFetcherConfig {
         .add("readTimeOut=" + readTimeOut)
         .add("writeTimeOut=" + writeTimeOut)
         .add("callTimeOut=" + callTimeOut)
+        .add("maxContentLength=" + maxContentLength.toMegabytes() + "MB")
         .toString();
   }
 }

--- a/vat-crawler/src/test/java/be/dnsbelgium/mercator/vat/domain/PageFetcherTest.java
+++ b/vat-crawler/src/test/java/be/dnsbelgium/mercator/vat/domain/PageFetcherTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.slf4j.Logger;
-
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.time.Duration;
@@ -30,6 +29,8 @@ class PageFetcherTest {
   private static boolean isHttpbinDisabled() {
     return true;
   }
+
+
 
   @Test
   public void fetchGoogle() throws IOException {
@@ -181,4 +182,11 @@ class PageFetcherTest {
     assertThat(page.getStatusCode()).isEqualTo(200);
   }
 
+  @Test
+  public void fetchPageWithoutContentLengthHeaderAndBodyLengthOverMax() throws IOException {
+    PageFetcher testFetcher = new PageFetcher(meterRegistry, PageFetcherConfig.testConfig());
+    testFetcher.clearCache();
+    Page page = testFetcher.fetch(HttpUrl.get("http://www.google.be"));
+    assertThat(page).isEqualTo(Page.PAGE_TOO_BIG);
+  }
 }

--- a/vat-crawler/src/test/java/be/dnsbelgium/mercator/vat/domain/VatScraperTest.java
+++ b/vat-crawler/src/test/java/be/dnsbelgium/mercator/vat/domain/VatScraperTest.java
@@ -6,7 +6,10 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.springframework.core.io.ClassPathResource;
@@ -16,6 +19,8 @@ import java.io.IOException;
 import java.util.List;
 
 import lombok.SneakyThrows;
+import org.testcontainers.shaded.org.apache.commons.lang3.StringUtils;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 
@@ -124,6 +129,31 @@ class VatScraperTest {
             .withBody(body)
             .withHeader("Content-Type", "text/html; charset=UTF-8"))
     );
+  }
+
+  @Test
+  @Disabled
+  public void fetchPageAndParseTestWith1PageThatErrors() throws IOException {
+    HttpUrl baseUrl;
+    String BIG_BODY = StringUtils.repeat("abcdefghjiklmnopqrst", 10_000_000);
+    try (MockWebServer mockWebServer = new MockWebServer()) {
+      MockResponse response = new MockResponse()
+        .setChunkedBody(BIG_BODY, 100);
+      PageFetcher testFetcher = new PageFetcher(meterRegistry, PageFetcherConfig.testConfig());
+      testFetcher.clearCache();
+      VatScraper testVatScraper = new VatScraper(meterRegistry, testFetcher, new VatFinder(), new LinkPrioritizer());
+      mockWebServer.enqueue(response);
+      mockWebServer.enqueue(new MockResponse().setBody("test"));
+      mockWebServer.start();
+      baseUrl = mockWebServer.url("/");
+      Page page1 = testVatScraper.fetchAndParse(baseUrl);
+      assertThat(page1).isEqualTo(null);
+      testFetcher.clearCache();
+      Page page2 = testVatScraper.fetchAndParse(baseUrl);
+      logger.info("page = {}", page2);
+      assertThat(page2.getStatusCode()).isEqualTo(200);
+      assertThat(page2.getResponseBody()).isEqualTo("test");
+    }
   }
 
 }


### PR DESCRIPTION
Added a test to check if a response without a content-length header and a bigger body than allowed gets processed correctly. PageFetcherConfig now also includes a testConfig with a smaller limit to the content-length.